### PR TITLE
Make dataset path and launcher timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ make run-slurm
 
 If no GPU is available the script prints a friendly message and exits.
 
+## Configuration
+
+- `DATA_PATH` – dataset download path for training scripts (default `/tmp/data`)
+- `SIGTERM_TIMEOUT` – seconds the launcher waits after SIGTERM before forcing termination
+
 ## NCCL tuning cheat sheet
 
 - `NCCL_SOCKET_IFNAME` – network interface (e.g., `eth0`)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,7 +9,8 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "train"))
 import dataset
 
 
-def test_dataset_shape():
+def test_dataset_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_PATH", str(tmp_path))
     loader = dataset.get_dataloader(batch_size=4)
     images, labels = next(iter(loader))
     assert images.shape == (4, 3, 32, 32)

--- a/train/dataset.py
+++ b/train/dataset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import torch
 from torch.utils.data import DataLoader, Dataset
 
@@ -25,12 +27,27 @@ class RandomDataset(Dataset):
         return x, y
 
 
-def get_dataset(data_path: str = "/tmp/data") -> Dataset:
+def get_dataset(data_path: str | None = None) -> Dataset:
+    """Return CIFAR10 or a synthetic dataset.
+
+    Parameters
+    ----------
+    data_path:
+        Directory to download/load the dataset from. If ``None`` the path is
+        read from the ``DATA_PATH`` environment variable and defaults to
+        ``/tmp/data`` when unset.
+    """
+
+    if data_path is None:
+        data_path = os.environ.get("DATA_PATH", "/tmp/data")
+
     if HAS_TORCHVISION:
         transform = transforms.ToTensor()
         return datasets.CIFAR10(root=data_path, train=True, download=True, transform=transform)
     return RandomDataset()
 
 
-def get_dataloader(batch_size: int = 4, data_path: str = "/tmp/data") -> DataLoader:
+def get_dataloader(batch_size: int = 4, data_path: str | None = None) -> DataLoader:
+    """Return a dataloader for the configured dataset."""
+
     return DataLoader(get_dataset(data_path), batch_size=batch_size)

--- a/train/ddp_launcher.py
+++ b/train/ddp_launcher.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -12,6 +13,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Spawn per-GPU workers")
     parser.add_argument("script", help="Training script to run")
     parser.add_argument("script_args", nargs=argparse.REMAINDER)
+    parser.add_argument(
+        "--sigterm-timeout",
+        type=float,
+        default=float(os.environ.get("SIGTERM_TIMEOUT", "10")),
+        help="Seconds to wait after SIGTERM before forcing termination (env: SIGTERM_TIMEOUT)",
+    )
     return parser.parse_args()
 
 
@@ -23,19 +30,39 @@ def main() -> None:
     if n_gpus == 0 and env_world_size is None:
         raise RuntimeError("No GPUs found and WORLD_SIZE not specified")
     world_size = int(env_world_size) if env_world_size else n_gpus
+
+    master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
+    master_port = int(os.environ.get("MASTER_PORT", "29500"))
+
+    # Fail fast if the master is unreachable or the port is already in use
+    try:
+        with socket.create_connection((master_addr, master_port), timeout=2):
+            pass
+    except OSError:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(2)
+            try:
+                sock.bind((master_addr, master_port))
+            except OSError as exc:  # pragma: no cover - network dependent
+                raise RuntimeError(
+                    f"MASTER_ADDR {master_addr}:{master_port} unreachable or port unavailable"
+                ) from exc
+
     processes: list[subprocess.Popen] = []
 
     def handle_sigterm(signum, frame):  # noqa: ARG001
-        timeout = 10
         for p in processes:
             p.send_signal(signum)
 
-        start = time.time()
-        while True:
-            alive = [p for p in processes if p.poll() is None]
-            if not alive or (time.time() - start) > timeout:
+        deadline = time.time() + args.sigterm_timeout
+        for p in processes:
+            remaining = deadline - time.time()
+            if remaining <= 0:
                 break
-            time.sleep(0.5)
+            try:
+                p.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                pass
 
         for p in processes:
             if p.poll() is None:
@@ -51,14 +78,15 @@ def main() -> None:
                 "LOCAL_RANK": str(local_rank),
                 "RANK": str(base_rank + local_rank),
                 "WORLD_SIZE": str(world_size),
-                "MASTER_ADDR": os.environ.get("MASTER_ADDR", "127.0.0.1"),
-                "MASTER_PORT": os.environ.get("MASTER_PORT", "29500"),
+                "MASTER_ADDR": master_addr,
+                "MASTER_PORT": str(master_port),
             }
         )
-        script_path = os.path.abspath(args.script)
-        if not os.path.exists(script_path):
+        script_path = os.path.realpath(args.script)
+        if not os.path.isfile(script_path):
             raise FileNotFoundError(script_path)
-        cmd = [sys.executable, script_path] + list(args.script_args)
+        cmd = [sys.executable, script_path, *args.script_args]
+        # Pass a list with shell=False to avoid shell injection
         processes.append(subprocess.Popen(cmd, env=env, shell=False))
 
     codes = [p.wait() for p in processes]

--- a/train/main.py
+++ b/train/main.py
@@ -30,6 +30,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch-size", type=int, default=32)
     parser.add_argument("--mixed-precision", action="store_true")
+    parser.add_argument(
+        "--data-path",
+        default=os.environ.get("DATA_PATH", "/tmp/data"),
+        help="Dataset path (env: DATA_PATH)",
+    )
     return parser.parse_args()
 
 
@@ -47,7 +52,7 @@ def main() -> None:
     criterion = nn.CrossEntropyLoss().to(device)
     scaler = torch.cuda.amp.GradScaler(enabled=args.mixed_precision)
 
-    dataset_obj = dataset.get_dataset()
+    dataset_obj = dataset.get_dataset(args.data_path)
     sampler = DistributedSampler(dataset_obj)
     loader = DataLoader(dataset_obj, batch_size=args.batch_size, sampler=sampler)
 


### PR DESCRIPTION
## Summary
- Allow dataset path to be set via `DATA_PATH` env or `--data-path` flag
- Expose `--sigterm-timeout` for DDP launcher and validate master address/port
- Document new environment variables and extend dataset test

## Testing
- `python -m py_compile train/dataset.py train/main.py train/ddp_launcher.py tests/test_dataset.py`
- `pytest tests/test_dataset.py` *(skipped: torch not installed)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_6898dda8513c8323af90a628b1e01aa6

## Summary by Sourcery

Allow customizing dataset storage path and DDP launcher termination behavior, add connectivity checks for master endpoint, and update documentation and tests accordingly.

New Features:
- Make dataset path configurable via DATA_PATH environment variable or --data-path flag in training scripts
- Expose --sigterm-timeout flag and SIGTERM_TIMEOUT environment variable to control DDP launcher graceful shutdown duration
- Validate MASTER_ADDR and MASTER_PORT reachability or availability before spawning DDP processes

Enhancements:
- Use os.path.realpath and isfile for script validation and disable shell execution in subprocess calls
- Update README with DATA_PATH and SIGTERM_TIMEOUT configuration options

Tests:
- Extend dataset loader test to set DATA_PATH via environment and verify data shapes