### PR TITLE
Improve dataset path logging and SIGTERM cleanup

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -9,9 +10,40 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "train"))
 import dataset
 
 
-def test_dataset_shape(tmp_path, monkeypatch):
+def test_dataset_env_path(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_PATH", str(tmp_path))
+    monkeypatch.setattr(dataset, "HAS_TORCHVISION", False)
     loader = dataset.get_dataloader(batch_size=4)
     images, labels = next(iter(loader))
     assert images.shape == (4, 3, 32, 32)
     assert labels.shape == (4,)
+
+
+def test_dataset_explicit_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(dataset, "HAS_TORCHVISION", False)
+    loader = dataset.get_dataloader(batch_size=2, data_path=str(tmp_path))
+    images, labels = next(iter(loader))
+    assert images.shape == (2, 3, 32, 32)
+    assert labels.shape == (2,)
+
+
+def test_dataset_fallback_path(monkeypatch, caplog):
+    monkeypatch.delenv("DATA_PATH", raising=False)
+    monkeypatch.setattr(dataset, "HAS_TORCHVISION", False)
+    with caplog.at_level("INFO"):
+        _ = dataset.get_dataset()
+    assert "Resolved data_path: /tmp/data" in caplog.text
+
+
+def test_dataset_invalid_path(monkeypatch):
+    monkeypatch.setattr(dataset, "HAS_TORCHVISION", True)
+
+    class DummyCIFAR10:
+        def __init__(self, root, train, download, transform):
+            raise OSError("invalid path")
+
+    monkeypatch.setattr(dataset, "datasets", SimpleNamespace(CIFAR10=DummyCIFAR10))
+    monkeypatch.setattr(dataset, "transforms", SimpleNamespace(ToTensor=lambda: None))
+
+    with pytest.raises(OSError):
+        dataset.get_dataset(data_path="/invalid/path")

--- a/train/dataset.py
+++ b/train/dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 
 import torch
@@ -40,6 +41,7 @@ def get_dataset(data_path: str | None = None) -> Dataset:
 
     if data_path is None:
         data_path = os.environ.get("DATA_PATH", "/tmp/data")
+        logging.info("Resolved data_path: %s", data_path)
 
     if HAS_TORCHVISION:
         transform = transforms.ToTensor()

--- a/train/ddp_launcher.py
+++ b/train/ddp_launcher.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import signal
 import socket
@@ -64,9 +65,13 @@ def main() -> None:
             except subprocess.TimeoutExpired:
                 pass
 
-        for p in processes:
+        for idx, p in enumerate(processes):
             if p.poll() is None:
-                p.terminate()
+                logging.warning(
+                    "Process %s did not terminate after SIGTERM, sending SIGKILL",
+                    idx,
+                )
+                p.kill()
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 


### PR DESCRIPTION
## Summary
- log worker processes that require SIGKILL after SIGTERM timeout
- log resolved dataset path when environment variable fallback is used
- expand dataset tests to cover explicit, default, and invalid paths

## Testing
- `pre-commit run --files train/ddp_launcher.py train/dataset.py tests/test_dataset.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found)*
- `pytest -q`
- `python -m py_compile train/ddp_launcher.py train/dataset.py tests/test_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6898e071df388323ad6c4ad57afdbc6c

## Summary by Sourcery

Refine process cleanup in the DDP launcher, add dataset path resolution logging, and bolster dataset loader test coverage for various path scenarios

Enhancements:
- Log a warning and send SIGKILL to processes that remain after SIGTERM in the DDP launcher
- Log the resolved data_path when falling back to the environment variable or default in the dataset module

Tests:
- Add dataset loader tests for environment variable, explicit, fallback, and invalid data_path scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset loading reliability and error handling, including better handling of invalid or missing data paths.

* **New Features**
  * Added informative logging for dataset path resolution and process termination during distributed training.

* **Tests**
  * Enhanced test coverage for dataset loading scenarios, including environment variable handling, explicit paths, fallback behavior, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->