### PR TITLE
Improve process termination logging and dataset path visibility

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -19,9 +19,11 @@ def test_dataset_env_path(tmp_path, monkeypatch):
     assert labels.shape == (4,)
 
 
-def test_dataset_explicit_path(tmp_path, monkeypatch):
+def test_dataset_explicit_path(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(dataset, "HAS_TORCHVISION", False)
-    loader = dataset.get_dataloader(batch_size=2, data_path=str(tmp_path))
+    with caplog.at_level("INFO"):
+        loader = dataset.get_dataloader(batch_size=2, data_path=str(tmp_path))
+    assert f"Resolved data_path: {tmp_path}" in caplog.text
     images, labels = next(iter(loader))
     assert images.shape == (2, 3, 32, 32)
     assert labels.shape == (2,)

--- a/train/dataset.py
+++ b/train/dataset.py
@@ -41,7 +41,7 @@ def get_dataset(data_path: str | None = None) -> Dataset:
 
     if data_path is None:
         data_path = os.environ.get("DATA_PATH", "/tmp/data")
-        logging.info("Resolved data_path: %s", data_path)
+    logging.info("Resolved data_path: %s", data_path)
 
     if HAS_TORCHVISION:
         transform = transforms.ToTensor()

--- a/train/ddp_launcher.py
+++ b/train/ddp_launcher.py
@@ -68,10 +68,12 @@ def main() -> None:
         for idx, p in enumerate(processes):
             if p.poll() is None:
                 logging.warning(
-                    "Process %s did not terminate after SIGTERM, sending SIGKILL",
+                    "Process %s (pid %s) did not terminate after SIGTERM, sending SIGKILL",
                     idx,
+                    p.pid,
                 )
                 p.kill()
+                p.wait()
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 


### PR DESCRIPTION
## Summary
- log PID of lingering worker processes and forcefully kill them when SIGTERM is ignored
- always log resolved dataset path
- test dataset path selection and logging

## Testing
- `pre-commit run --files train/ddp_launcher.py train/dataset.py tests/test_dataset.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q` *(skipped: 1 skipped)*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6898ecefea6c8323be3fd9a6a501981b

## Summary by Sourcery

Improve process termination logging to include worker PID and wait for kill completion, ensure dataset path resolution is always logged, and add tests to verify dataset path logging

Enhancements:
- Log process index and PID when SIGTERM is ignored and wait for the kill to complete
- Always emit an info log for the resolved dataset path regardless of whether it’s provided or defaulted

Tests:
- Add a caplog-based test to verify that get_dataloader logs the resolved dataset path