### PR TITLE
Improve signal cleanup and dataset logging

### DIFF
--- a/train/dataset.py
+++ b/train/dataset.py
@@ -41,7 +41,9 @@ def get_dataset(data_path: str | None = None) -> Dataset:
 
     if data_path is None:
         data_path = os.environ.get("DATA_PATH", "/tmp/data")
-    logging.info("Resolved data_path: %s", data_path)
+        logging.info("Using data_path: %s", data_path)
+    else:
+        logging.debug("Using data_path: %s", data_path)
 
     if HAS_TORCHVISION:
         transform = transforms.ToTensor()


### PR DESCRIPTION
## Summary
- handle SIGTERM and SIGINT with shared shutdown routine and add timeout after SIGKILL
- reduce `get_dataset` data path logging to DEBUG when provided explicitly

## Testing
- `python -m pytest`
- `pre-commit run --files train/ddp_launcher.py train/dataset.py` *(fails: command not found; attempted `pip install pre-commit` but no matching distribution due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6898eec592c083238625ccb545a3c0c5

## Summary by Sourcery

Improve process shutdown robustness by handling SIGTERM and SIGINT uniformly with a timeout for SIGKILL, and reduce verbosity of dataset path logging when provided explicitly.

Enhancements:
- Unify shutdown handling for SIGTERM and SIGINT with a shared handler, adding a timeout after SIGKILL and error logging for unresponsive processes
- Lower log level for explicit data_path resolution in get_dataset from INFO to DEBUG